### PR TITLE
feat: add shadow opacity slider

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -51,7 +51,8 @@ export default function ScreenshotEditor() {
         offsetY: 20,
         blur: 40,
         spread: 0,
-        color: "rgba(0,0,0,0.3)",
+        color: "#000000",
+        opacity: 0.3,
         enabled: true,
       },
     ],
@@ -163,10 +164,12 @@ export default function ScreenshotEditor() {
 
   const shadowString = state.shadows
     .filter((s) => s.enabled)
-    .map(
-      (s) =>
-        `${s.offsetX}px ${s.offsetY}px ${s.blur}px ${s.spread}px ${s.color}`,
-    )
+    .map((s) => {
+      const r = Number.parseInt(s.color.slice(1, 3), 16);
+      const g = Number.parseInt(s.color.slice(3, 5), 16);
+      const b = Number.parseInt(s.color.slice(5, 7), 16);
+      return `${s.offsetX}px ${s.offsetY}px ${s.blur}px ${s.spread}px rgba(${r},${g},${b},${s.opacity})`;
+    })
     .join(", ");
 
   const tabs = [

--- a/components/ShadowControls.tsx
+++ b/components/ShadowControls.tsx
@@ -54,30 +54,30 @@ export default function ShadowControls({
         max={100}
         unit="px"
       />
+      <Slider
+        label="Opacity"
+        value={state.shadows[0].opacity}
+        onChange={(v: number) =>
+          setState((prev) => ({
+            ...prev,
+            shadows: [{ ...prev.shadows[0], opacity: v }],
+          }))
+        }
+        min={0}
+        max={1}
+        step={0.01}
+      />
       <div className="space-y-2">
         <Label className="text-xs text-muted-foreground">Shadow Color</Label>
         <input
           type="color"
-          value={state.shadows[0].color.replace(
-            /rgba?\((\d+),\s*(\d+),\s*(\d+).*\)/,
-            (_, r, g, b) =>
-              "#" +
-              [r, g, b]
-                .map((x) => Number.parseInt(x, 10).toString(16).padStart(2, "0"))
-                .join(""),
-          )}
-          onChange={(e) => {
-            const hex = e.target.value;
-            const r = Number.parseInt(hex.slice(1, 3), 16);
-            const g = Number.parseInt(hex.slice(3, 5), 16);
-            const b = Number.parseInt(hex.slice(5, 7), 16);
+          value={state.shadows[0].color}
+          onChange={(e) =>
             setState((prev) => ({
               ...prev,
-              shadows: [
-                { ...prev.shadows[0], color: `rgba(${r},${g},${b},0.3)` },
-              ],
-            }));
-          }}
+              shadows: [{ ...prev.shadows[0], color: e.target.value }],
+            }))
+          }
           className="w-16 h-8 rounded-none cursor-pointer"
         />
       </div>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -26,6 +26,7 @@ interface ShadowLayer {
   blur: number;
   spread: number;
   color: string;
+  opacity: number;
   enabled: boolean;
 }
 


### PR DESCRIPTION
Adds a shadow opacity slider to the shadow customization tab, allowing you to change shadow intensity.

I would probably suggest changing the standard color picker to one that supports alpha values, but I did it like this to align with the rest of the codebase. I also kept lg:grid-cols-4 since it's the same for other customization tabs.

<img width="1697" height="1049" alt="image" src="https://github.com/user-attachments/assets/5cdde142-a70e-4c8a-8098-ab658c798185" />
