### PR TITLE
feat: add background image blur

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -76,6 +76,7 @@ export default function ScreenshotEditor() {
     address: "https://screenpastel.vercel.app",
     backgroundTintColor: "#000000",
     backgroundTintOpacity: 0,
+    backgroundBlur: 0,
   });
 
   const canvasRef = useRef<HTMLDivElement>(null);
@@ -269,12 +270,17 @@ export default function ScreenshotEditor() {
             ) : (
               <div
                 ref={canvasRef}
-                style={{
-                  background: state.background.value,
-                  padding: `${state.padding}px`,
-                }}
-                className="relative"
+                style={{ padding: `${state.padding}px` }}
+                className="relative overflow-hidden"
               >
+                <div
+                  className="absolute pointer-events-none"
+                  style={{
+                    background: state.background.value,
+                    filter: state.backgroundBlur > 0 ? `blur(${state.backgroundBlur}px)` : undefined,
+                    inset: state.backgroundBlur > 0 ? `-${state.backgroundBlur}px` : 0,
+                  }}
+                />
                 {state.backgroundTintOpacity > 0 && (
                   <div
                     className="absolute inset-0 pointer-events-none"

--- a/components/BackgroundControls.tsx
+++ b/components/BackgroundControls.tsx
@@ -1,9 +1,8 @@
 "use client";
 import type React from "react";
-import { Label } from "@/components/ui/label";
-import { Slider } from "@/components/ui/slider";
 import GradientControls from "./GradientControls";
 import ImageControls from "./ImageControls";
+import Slider from "./Slider";
 import type { EditorState } from "../lib/types";
 
 export default function BackgroundControls({
@@ -22,46 +21,53 @@ export default function BackgroundControls({
                     <GradientControls state={state} setState={setState} />
                 </div>
             </div>
-            {state.background.type === "gradient" && (
-                <div className="space-y-1.5">
-                    <Label className="text-xs text-muted-foreground">Direction</Label>
-                    <div className="flex items-center gap-2">
-                        <Slider
-                            value={[state.gradientDirection]}
-                            onValueChange={([value]) =>
-                                setState((prev) => {
-                                    const newDirection = value;
-                                    let updatedBackground = prev.background;
-                                    if (prev.background.type === "gradient") {
-                                        const match = prev.background.value.match(
-                                            /linear-gradient\(\d+deg, (.+)\)/,
-                                        );
-                                        if (match) {
-                                            const colors = match[1];
-                                            updatedBackground = {
-                                                ...prev.background,
-                                                value: `linear-gradient(${newDirection}deg, ${colors})`,
-                                            };
-                                        }
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-6 max-w-5xl">
+                <Slider
+                    label="Blur"
+                    value={state.backgroundBlur}
+                    onChange={(v: number) =>
+                        setState((prev) => ({ ...prev, backgroundBlur: v }))
+                    }
+                    min={0}
+                    max={50}
+                    unit="px"
+                />
+
+                {state.background.type === "gradient" && (
+                    <Slider
+                        label="Direction"
+                        value={state.gradientDirection}
+                        onChange={(v: number) =>
+                            setState((prev) => {
+                                const newDirection = v;
+                                let updatedBackground = prev.background;
+
+                                if (prev.background.type === "gradient") {
+                                    const match = prev.background.value.match(
+                                        /linear-gradient\(\d+deg, (.+)\)/,
+                                    );
+                                    if (match) {
+                                        const colors = match[1];
+                                        updatedBackground = {
+                                            ...prev.background,
+                                            value: `linear-gradient(${newDirection}deg, ${colors})`,
+                                        };
                                     }
-                                    return {
-                                        ...prev,
-                                        gradientDirection: newDirection,
-                                        background: updatedBackground,
-                                    };
-                                })
-                            }
-                            min={0}
-                            max={360}
-                            step={1}
-                            className="max-w-1/4"
-                        />
-                        <div className="text-xs text-muted-foreground w-12 text-center">
-                            {state.gradientDirection}°
-                        </div>
-                    </div>
-                </div>
-            )}
+                                }
+
+                                return {
+                                    ...prev,
+                                    gradientDirection: newDirection,
+                                    background: updatedBackground,
+                                };
+                            })
+                        }
+                        min={0}
+                        max={360}
+                        unit="°"
+                    />
+                )}
+            </div>
         </>
     );
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -63,6 +63,7 @@ interface EditorState {
   address: string;
   backgroundTintColor: string;
   backgroundTintOpacity: number;
+  backgroundBlur: number;
 }
 
 export type { WindowFrame, Background, Theme, ShadowLayer, StackConfig, EditorState };


### PR DESCRIPTION
Adds a blur slider to the background customization tab, allowing you to add blur to the background.

The diff is a bit bigger than the actual code changes because I wanted the blur slider to have a consistent placement when switching between custom images and gradients. I used the same patterns as the other tabs' settings.

Custom image:
<img width="1412" height="1049" alt="image" src="https://github.com/user-attachments/assets/6ae3b752-e406-4347-bd6e-79a09b1a5e14" />
Gradient:
<img width="1413" height="1047" alt="image" src="https://github.com/user-attachments/assets/1fe9beb2-0f02-4c73-87cb-74b81b1e76f8" />
